### PR TITLE
adding in validation for your URL

### DIFF
--- a/app/assets/javascripts/tests.coffee
+++ b/app/assets/javascripts/tests.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/tests.js
+++ b/app/assets/javascripts/tests.js
@@ -1,0 +1,18 @@
+$(document).ready(function() {
+  $("#toggle").click((function(){
+    var counter = 1;
+    return function()
+    {
+       $(".q" + counter).hide();
+       counter = counter + 1;
+       $(".q" + counter).show();
+    };
+  })());
+  $("#start").click((function(){
+    return function()
+    {
+       $("#iframe, .q1, #toggle").show();
+       $(".welcome").hide();
+    };
+  })());
+});

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -9,8 +9,10 @@ class TestsController < ApplicationController
   def create
     @test = Test.new(test_params)
     if @test.save
+      flash[:success] = "Test saved!"
       redirect_to thanks_test_path(@test)
     else
+      flash[:error] = @test.errors.full_messages.map{|o| o  }.join("")
       redirect_to new_test_path
     end
   end
@@ -28,6 +30,10 @@ class TestsController < ApplicationController
 
   def test_params
     params.require(:test).permit(:name, :test_url, :test_type_id, :question_ids => [])
+  end
+
+  def check_url(url)
+    puts url
   end
 
 end

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -9,7 +9,6 @@ class TestsController < ApplicationController
   def create
     @test = Test.new(test_params)
     if @test.save
-      flash[:success] = "Test saved!"
       redirect_to thanks_test_path(@test)
     else
       flash[:error] = @test.errors.full_messages.map{|o| o  }.join("")
@@ -30,10 +29,6 @@ class TestsController < ApplicationController
 
   def test_params
     params.require(:test).permit(:name, :test_url, :test_type_id, :question_ids => [])
-  end
-
-  def check_url(url)
-    puts url
   end
 
 end

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -5,4 +5,9 @@ class Test < ApplicationRecord
   has_one :test_type
   has_and_belongs_to_many :questions, join_table: "tests_questions"
   has_many :answers, through: :questions
+
+  validates :test_url, presence: true
+  validates :name, presence: true
+  validates :test_url, format: { with: URI.regexp }, if: 'test_url.present?'
+
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,6 +11,8 @@
     %body
 
     = render 'layouts/nav'
+    - flash.each do |key, value|
+      %div{:class => "alert alert-#{key}"}= value
 
     = yield
 

--- a/app/views/tests/new.html.haml
+++ b/app/views/tests/new.html.haml
@@ -1,6 +1,6 @@
 = form_for @test do |f|
-  = f.text_field(:name, placeholder: "Your test name")
-  = f.text_field(:test_url, placeholder: "URL for testing")
+  = f.text_field(:name, placeholder: "Your test name", :required => true)
+  = f.text_field(:test_url, placeholder: "URL for testing", :required => true)
   = f.select :test_type_id, options_for_select(@test_types.map{ |t| [t.description, t.id] })
   %br
   = f.label "Choose the questions you'd like to ask:"

--- a/app/views/tests/show.html.haml
+++ b/app/views/tests/show.html.haml
@@ -35,24 +35,3 @@
 
 %iframe{allowfullscreen: "", id:"iframe", src: "https://www.youtube.com/embed/XGSy3_Czz8k", width: "800", height: "600", style: "display:none"}
   %p Sorry, something seems to have gone wrong!
-
-%script
-:javascript
-  $(document).ready(function() {
-    $("#toggle").click((function(){
-      var counter = 1;
-      return function()
-      {
-         $(".q" + counter).hide();
-         counter = counter + 1;
-         $(".q" + counter).show();
-      }
-      })());
-    $("#start").click((function(){
-      return function()
-      {
-         $("#iframe, .q1, #toggle").show();
-         $(".welcome").hide();
-      }
-      })());
-  });

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,9 @@ Bundler.require(*Rails.groups)
 
 module Uxbuddy
   class Application < Rails::Application
+    config.action_dispatch.default_headers = {
+      'X-Frame-Options' => 'ALLOWALL'
+    }
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/spec/features/creating_test_feature_spec.rb
+++ b/spec/features/creating_test_feature_spec.rb
@@ -15,6 +15,13 @@ feature 'User can create new tests' do
     expect(page).to have_content("Share test for Asos Product Test")
   end
 
+  scenario 'User cannot submit a test without a valid URL' do
+    start_creating_test("myURL", "not_a_url")
+    check 'test_question_ids_1'
+    click_button "Create Test"
+    expect(page).to have_content("Test url is invalid")
+  end
+
   scenario 'User can check multiple questions' do
     start_creating_test
     check 'test_question_ids_1'

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -21,7 +21,7 @@ module FeatureHelpers
     click_button("Log in")
   end
 
-  def start_creating_test(test_name = "Asos Product Test", test_url = "www.asos.com")
+  def start_creating_test(test_name = "Asos Product Test", test_url = "http://www.asos.com")
     visit '/tests/new'
     fill_in 'test_name', with: test_name
     fill_in 'test_test_url', with: test_url


### PR DESCRIPTION
closes #56 

@mrmurtz @Tim3tang @rosieallott @AbigailMcP  -- This ticket does two things:

1) It adds HTML 5 validation to the form - you can't submit it without a name and an URL
2) It adds database validation to make sure it's a full url like "http://www.google.com"
3) Adds a flash message if your URL is invalid

I didn't actually do any formatting of the URL. Will add a ticket to the backlog to:

a) format the URL if the user enters something like "www.google.com" or "google.com"
b) producing a friendlier URL message
c) saving a user's choices if we reload the page on them 
