### PR TITLE
hyperlink to new test provided when test created

### DIFF
--- a/app/views/tests/share.html.haml
+++ b/app/views/tests/share.html.haml
@@ -6,4 +6,4 @@
   Here's your testing prototype link:
 
 #url
-  = uxbuddy_test_url
+  =link_to uxbuddy_test_url, "#{uxbuddy_test_url}", class: "active"

--- a/spec/features/creating_test_feature_spec.rb
+++ b/spec/features/creating_test_feature_spec.rb
@@ -12,7 +12,7 @@ feature 'User can create new tests' do
     create_test("Climate", "http://www.climate.com")
     url = "http://www.example.com/tests/climate"
     expect(page).to have_content("Share test for Climate")
-    expect(page).to have_content(url)
+    expect(page).to have_link('', href: url)
   end
 
   scenario 'User cannot submit a test without a valid URL' do


### PR DESCRIPTION
closes #85 

Changed url to be hyperlink and amended test case to check for link. 

'Copy to clipboard' functionality can be done using jquery, but not completed on this branch. 
