### PR TITLE
fixing get started button

### DIFF
--- a/app/views/application/index.html.haml
+++ b/app/views/application/index.html.haml
@@ -11,4 +11,4 @@
   .col.s7
     %h3.strong.valign What are you waiting for?
   .col.s4
-    =button_to "Get started", new_test_path, method: :get, class: "btn-large waves-effect waves-light valign"
+    %a.btn-large.waves-effect.waves-light.valign{:href => new_test_path} Get started

--- a/spec/features/creating_test_feature_spec.rb
+++ b/spec/features/creating_test_feature_spec.rb
@@ -4,7 +4,7 @@ feature 'User can create new tests' do
 
   scenario 'Homepage has link to get started' do
     visit '/'
-    click_button 'Get started'
+    click_on 'Get started'
     expect(current_path).to eq('/tests/new')
   end
 

--- a/spec/features/tests_feature_spec.rb
+++ b/spec/features/tests_feature_spec.rb
@@ -17,7 +17,7 @@ feature 'User can see a test' do
       click_button('Start')
       expect(page).to have_xpath("//iframe[@src= 'https://www.youtube.com/embed/XGSy3_Czz8k']")
       expect(page).not_to have_xpath("//iframe[@src= 'other-url']")
-      expect(page).to have_content("How would you rate the information available about the product?")
+      expect(page).to have_content("How easy is it to know if this product is available?")
     end
   end
 


### PR DESCRIPTION
closes #82 

just changed the link so that that whole button is clickable rather than just the text ... 
