### PR TITLE
Turned the drop down into radio buttons, added DB column for the stat…

### DIFF
--- a/app/assets/stylesheets/tests.scss
+++ b/app/assets/stylesheets/tests.scss
@@ -1,3 +1,13 @@
 // Place all the styles related to the tests controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+
+#create-test-form {
+  margin-top: 3em;
+}
+
+#test-form-col {
+  margin-left: 0;
+  padding-left: 0;
+}

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -36,4 +36,9 @@ class TestsController < ApplicationController
     params.require(:test).permit(:name, :test_url, :test_type_id, :question_ids => [])
   end
 
+  def status
+    self.status
+  end
+
+
 end

--- a/app/views/tests/new.html.haml
+++ b/app/views/tests/new.html.haml
@@ -1,14 +1,20 @@
-.row
+.row#create-test-form
   .col.s8.offset-s2
     %h2 Create a new test
     = form_for @test do |f|
+      .col.s12#test-form-col
+      %h5 What is your test name?
       = f.text_field(:name, placeholder: "Your test name")
+      %h5 What URL are you testing?
       = f.text_field(:test_url, placeholder: "URL for testing")
-      .input-field
-        = f.select :test_type_id, options_for_select(@test_types.map{ |t| [t.description, t.id] })
-        %label Choose your test type
       %br
-      = f.label "Choose the questions you'd like to ask:"
+      %h5 What type of feature are you testing?
+      = f.collection_radio_buttons :test_type_id, @test_types, :id, :description do |t|
+        = t.radio_button
+        = t.label
+        %br
+      %br
+      %h5 What questions do you want to ask?
       %br
       = f.collection_check_boxes :question_ids, @questions, :id, :text do |q|
         = q.check_box

--- a/db/migrate/20161030115952_add_status_to_test_types.rb
+++ b/db/migrate/20161030115952_add_status_to_test_types.rb
@@ -1,0 +1,5 @@
+class AddStatusToTestTypes < ActiveRecord::Migration[5.0]
+  def change
+    add_column :test_types, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161029114836) do
+ActiveRecord::Schema.define(version: 20161030115952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20161029114836) do
     t.string   "description"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "status"
   end
 
   create_table "tests", force: :cascade do |t|

--- a/lib/assets/test_types.csv
+++ b/lib/assets/test_types.csv
@@ -1,2 +1,8 @@
-id,description,created_at,updated_at
-1,Product,,
+id,description,created_at,updated_at,status
+1,Product page,,,
+2,Search page,,,disabled
+3,Booking process,,,disabled
+4,FAQs,,,disabled
+5,Profile page,,,disabled
+6,Contact us,,,disabled
+7,Sign up,,,disabled

--- a/spec/features/creating_test_feature_spec.rb
+++ b/spec/features/creating_test_feature_spec.rb
@@ -36,7 +36,7 @@ feature 'User can create new tests' do
       visit '/tests/new'
       fill_in 'test_name', with: "BBC Test"
       fill_in 'test_test_url', with: "http://www.bbc.co.uk"
-      select('Product', from: 'test_test_type_id')
+      choose('Product page')
       check 'test_question_ids_1'
       check 'test_question_ids_2'
       question1 = find('#test_question_ids_1')
@@ -51,7 +51,7 @@ feature 'User can create new tests' do
       visit '/tests/new'
       fill_in 'test_name', with: 'test'
       fill_in 'test_test_url', with: 'https://www.test.com'
-      select('Product', from: 'test_test_type_id')
+      choose('Product page')
       click_button "Create Test"
       expect(page).to have_content("Question ids can't be blank")
     end

--- a/spec/features/tests_feature_spec.rb
+++ b/spec/features/tests_feature_spec.rb
@@ -17,7 +17,7 @@ feature 'User can see a test' do
       click_button('Start')
       expect(page).to have_xpath("//iframe[@src= 'https://www.youtube.com/embed/XGSy3_Czz8k']")
       expect(page).not_to have_xpath("//iframe[@src= 'other-url']")
-      expect(page).to have_content("How easy is it to know if this product is available?")
+      expect(page).to have_content("How would you rate the information available about the product?")
     end
   end
 

--- a/spec/question_spec.rb
+++ b/spec/question_spec.rb
@@ -14,7 +14,7 @@ describe Question do
       expect(Question.count).to eq(8)
     end
 
-    it 'should calculate the average of the responses' do # skipped as changes when you add more tests for answers 
+    xit 'should calculate the average of the responses' do # skipped as changes when you add more tests for answers 
       expect(question1.ave_response(test.id).round(1)).to eq(average.round(1))
     end
 

--- a/spec/question_spec.rb
+++ b/spec/question_spec.rb
@@ -14,7 +14,7 @@ describe Question do
       expect(Question.count).to eq(8)
     end
 
-    xit 'should calculate the average of the responses' do # skipped as changes when you add more tests for answers 
+    it 'should calculate the average of the responses' do # skipped as changes when you add more tests for answers 
       expect(question1.ave_response(test.id).round(1)).to eq(average.round(1))
     end
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -25,7 +25,7 @@ module FeatureHelpers
     click_link 'Get started'
     fill_in 'test_name', with: test_name
     fill_in 'test_test_url', with: test_url
-    select('Product', from: 'test_test_type_id')
+    choose('Product page')
     check 'test_question_ids_1'
     click_button "Create Test"
   end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -10,11 +10,11 @@ describe Test do
       expect(test3.questions.count).to eq(3)
     end
 
-    xit 'Test 1 should have 9 answers' do # skipped as changes when you add more tests for answers
+    it 'Test 1 should have 9 answers' do # skipped as changes when you add more tests for answers
       expect(test1.answers.where(test_id: test1.id).count).to eq(9)
     end
 
-    xit 'Test 1 should have 3 answers to Question 1' do # skipped as changes when you add more tests for answers 
+    it 'Test 1 should have 3 answers to Question 1' do # skipped as changes when you add more tests for answers 
       question_1 = test1.questions[0]
       answers_to_question_1 = question_1.answers.where(test_id: test1.id)
       expect(answers_to_question_1.count).to eq(3)

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -10,11 +10,11 @@ describe Test do
       expect(test3.questions.count).to eq(3)
     end
 
-    it 'Test 1 should have 9 answers' do # skipped as changes when you add more tests for answers
+    xit 'Test 1 should have 9 answers' do # skipped as changes when you add more tests for answers
       expect(test1.answers.where(test_id: test1.id).count).to eq(9)
     end
 
-    it 'Test 1 should have 3 answers to Question 1' do # skipped as changes when you add more tests for answers 
+    xit 'Test 1 should have 3 answers to Question 1' do # skipped as changes when you add more tests for answers
       question_1 = test1.questions[0]
       answers_to_question_1 = question_1.answers.where(test_id: test1.id)
       expect(answers_to_question_1.count).to eq(3)

--- a/spec/test_type_spec.rb
+++ b/spec/test_type_spec.rb
@@ -5,7 +5,7 @@ describe TestType do
     let(:product_type) { TestType.find(1) }
 
     it 'should load some data at the start' do
-      expect(TestType.count).to eq(1)
+      expect(TestType.count).to eq(7)
     end
 
     it 'should have 8 associated questions' do


### PR DESCRIPTION
closes #88 

This PR includes:
- new radio buttons for the test options
- a migration to add a status column to the test_types table
- the additional questions in the seed

still to be done: disabling the radio buttons based on the DB test_types.status
