### PR TITLE
179 screenshot aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+# Ignore AWS keys
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -37,9 +37,9 @@ gem 'chartkick'
 # IMGKit for site thumbnails
 gem "imgkit", "~> 1.3.7"
 # Amazon S3 storage
-gem 'aws-sdk', '~> 1.3.4'
+gem 'aws-sdk', '~> 2.3'
 # Paperclip for file uploads
-gem "paperclip", :git => "git://github.com/thoughtbot/paperclip.git"
+gem 'paperclip'
 gem 'wkhtmltopdf-binary'
 gem 'wkhtmltoimage-binary'
 gem 'dotenv-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,16 @@ gem 'jbuilder', '~> 2.5'
 gem 'haml'
 gem 'friendly_id', '~> 5.1.0'
 gem 'chartkick'
+# IMGKit for site thumbnails
+gem "imgkit", "~> 1.3.7"
+
+# Amazon S3 storage
+gem 'aws-sdk', '~> 1.3.4'
+
+# Paperclip for file uploads
+gem "paperclip", :git => "git://github.com/thoughtbot/paperclip.git"
+gem 'wkhtmltopdf-binary'
+gem 'wkhtmltoimage-binary'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -36,14 +36,13 @@ gem 'friendly_id', '~> 5.1.0'
 gem 'chartkick'
 # IMGKit for site thumbnails
 gem "imgkit", "~> 1.3.7"
-
 # Amazon S3 storage
 gem 'aws-sdk', '~> 1.3.4'
-
 # Paperclip for file uploads
 gem "paperclip", :git => "git://github.com/thoughtbot/paperclip.git"
 gem 'wkhtmltopdf-binary'
 gem 'wkhtmltoimage-binary'
+gem 'dotenv-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: git://github.com/thoughtbot/paperclip.git
+  revision: 915c904d9a1382f53f4dcc822878ebb7c2024bb6
+  specs:
+    paperclip (5.1.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      cocaine (~> 0.5.5)
+      mime-types
+      mimemagic (~> 0.3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -40,6 +51,11 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (7.1.4)
+    aws-sdk (1.3.9)
+      httparty (~> 0.7)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+      uuidtools (~> 2.1)
     bcrypt (3.1.11)
     builder (3.2.2)
     byebug (9.0.6)
@@ -51,7 +67,11 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     chartkick (2.1.1)
+    climate_control (0.0.3)
+      activesupport (>= 3.0)
     cliver (0.3.2)
+    cocaine (0.5.8)
+      climate_control (>= 0.0.3, < 1.0)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -89,7 +109,10 @@ GEM
       haml (~> 4.0.0)
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
+    imgkit (1.3.10)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -97,6 +120,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.0.8)
@@ -112,9 +136,11 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mimemagic (0.3.2)
     mini_portile2 (2.1.0)
     minitest (5.9.1)
     multi_json (1.12.1)
+    multi_xml (0.5.5)
     nio4r (1.2.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
@@ -206,6 +232,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.3)
       execjs (>= 0.3.0, < 3)
+    uuidtools (2.1.5)
     warden (1.2.6)
       rack (>= 1.0)
     web-console (3.3.1)
@@ -216,6 +243,8 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    wkhtmltoimage-binary (0.12.2)
+    wkhtmltopdf-binary (0.12.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -223,6 +252,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk (~> 1.3.4)
   byebug
   capybara
   chartkick
@@ -232,11 +262,13 @@ DEPENDENCIES
   friendly_id (~> 5.1.0)
   haml
   haml-rails (~> 0.9)
+  imgkit (~> 1.3.7)
   jbuilder (~> 2.5)
   jquery-rails
   launchy
   listen (~> 3.0.5)
   materialize-sass
+  paperclip!
   pg (~> 0.18)
   poltergeist
   puma (~> 3.0)
@@ -249,6 +281,8 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
+  wkhtmltoimage-binary
+  wkhtmltopdf-binary
 
 BUNDLED WITH
    1.13.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.14)
@@ -259,6 +263,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   database_cleaner
   devise
+  dotenv-rails
   friendly_id (~> 5.1.0)
   haml
   haml-rails (~> 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: git://github.com/thoughtbot/paperclip.git
-  revision: 915c904d9a1382f53f4dcc822878ebb7c2024bb6
-  specs:
-    paperclip (5.1.0)
-      activemodel (>= 4.2.0)
-      activesupport (>= 4.2.0)
-      cocaine (~> 0.5.5)
-      mime-types
-      mimemagic (~> 0.3.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -51,11 +40,12 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (7.1.4)
-    aws-sdk (1.3.9)
-      httparty (~> 0.7)
-      json (~> 1.4)
-      nokogiri (>= 1.4.4)
-      uuidtools (~> 2.1)
+    aws-sdk (2.6.5)
+      aws-sdk-resources (= 2.6.5)
+    aws-sdk-core (2.6.5)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.6.5)
+      aws-sdk-core (= 2.6.5)
     bcrypt (3.1.11)
     builder (3.2.2)
     byebug (9.0.6)
@@ -113,18 +103,16 @@ GEM
       haml (~> 4.0.0)
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
-    httparty (0.14.0)
-      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     imgkit (1.3.10)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
+    jmespath (1.3.1)
     jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.0.8)
@@ -144,11 +132,16 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.9.1)
     multi_json (1.12.1)
-    multi_xml (0.5.5)
     nio4r (1.2.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     orm_adapter (0.5.0)
+    paperclip (5.1.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      cocaine (~> 0.5.5)
+      mime-types
+      mimemagic (~> 0.3.0)
     pg (0.19.0)
     poltergeist (1.11.0)
       capybara (~> 2.1)
@@ -236,7 +229,6 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.3)
       execjs (>= 0.3.0, < 3)
-    uuidtools (2.1.5)
     warden (1.2.6)
       rack (>= 1.0)
     web-console (3.3.1)
@@ -256,7 +248,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk (~> 1.3.4)
+  aws-sdk (~> 2.3)
   byebug
   capybara
   chartkick
@@ -273,7 +265,7 @@ DEPENDENCIES
   launchy
   listen (~> 3.0.5)
   materialize-sass
-  paperclip!
+  paperclip
   pg (~> 0.18)
   poltergeist
   puma (~> 3.0)

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -77,8 +77,7 @@ class TestsController < ApplicationController
   def upload_image(test)
    url  = test.test_url
    img   = IMGKit.new(url).to_png
-   file  = Tempfile.new(["#{test.slug}", '.png'], 'tmp',
-                         :encoding => 'ascii-8bit')
+   file  = Tempfile.new(["#{test.slug}", '.png'], 'tmp', :encoding => 'ascii-8bit')
    file.write(img)
    file.flush
    test.snapshot = file

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -75,15 +75,15 @@ class TestsController < ApplicationController
   end
 
   def upload_image(test)
-   url  = test.test_url
-   img   = IMGKit.new(url).to_png
-   file  = Tempfile.new(["#{test.slug}", '.png'], 'tmp', :encoding => 'ascii-8bit')
+   url = test.test_url
+   img = IMGKit.new(url).to_png
+   file = Tempfile.new(["#{test.slug}", '.png'], 'tmp', :encoding => 'ascii-8bit')
    file.write(img)
    file.flush
    test.snapshot = file
    test.save
    file.unlink
-end
+  end
 
 
 end

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -18,6 +18,7 @@ class TestsController < ApplicationController
     if @test.save
       @test.update(user_id: current_user.id)
       @test.update(slug: @test.name.downcase.split(" ").join("-"))
+      upload_image(@test)
       redirect_to share_test_path(@test)
     else
       flash[:error] = @test.errors.full_messages.map{|o| o  }.join("/")
@@ -72,5 +73,18 @@ class TestsController < ApplicationController
       @test = Test.new
     end
   end
+
+  def upload_image(test)
+   url  = test.test_url
+   img   = IMGKit.new(url).to_png
+   file  = Tempfile.new(["#{test.slug}", '.png'], 'tmp',
+                         :encoding => 'ascii-8bit')
+   file.write(img)
+   file.flush
+   test.snapshot = file
+   test.save
+   file.unlink
+end
+
 
 end

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -6,7 +6,7 @@ class Test < ApplicationRecord
   has_one :test_type
   has_and_belongs_to_many :questions, join_table: "tests_questions"
   has_many :answers, through: :questions
-  has_attached_file :snapshot
+  has_attached_file :snapshot, styles: { medium: "700x", thumb: "100x100>" }
 
   # validates :user, presence: true
   validates :test_url, presence: true

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -6,6 +6,7 @@ class Test < ApplicationRecord
   has_one :test_type
   has_and_belongs_to_many :questions, join_table: "tests_questions"
   has_many :answers, through: :questions
+  has_attached_file :snapshot
 
   # validates :user, presence: true
   validates :test_url, presence: true
@@ -13,6 +14,7 @@ class Test < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: true
   validates :test_url, format: { with: URI.regexp }, if: 'test_url.present?'
+  validates_attachment_content_type :snapshot, :content_type => /\Aimage\/.*\Z/
 
   def number_respondents
     self.questions[0].answers.where(test_id: self.id).count

--- a/app/views/tests/index.html.haml
+++ b/app/views/tests/index.html.haml
@@ -4,7 +4,7 @@
     .col.s4
       .card
         .card-image.waves-effect.waves-block.waves-light
-          %img.activator{:src => "images/default_image.jpg"}/
+          %img{:src => test.snapshot.url(:original)}/
         .card-content
           %span.card-title.activator.grey-text.text-darken-4
             =test.name

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,6 +4,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
+
   config.cache_classes = false
 
   # Do not eager load code on boot.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,4 +53,15 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Amazon Web Services - S3
+  config.paperclip_defaults = {
+    storage: :s3,
+    s3_credentials: {
+      bucket: ENV.fetch('S3_BUCKET_NAME'),
+      access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
+      secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
+      s3_region: ENV.fetch('AWS_REGION'),
+    }
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,15 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Amazon Web Services S3
+  config.paperclip_defaults = {
+    storage: :s3,
+    s3_credentials: {
+      bucket: ENV.fetch('S3_BUCKET_NAME'),
+      access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
+      secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
+      s3_region: ENV.fetch('AWS_REGION'),
+    }
+  }
 end

--- a/db/migrate/20161101215031_add_attachment_snapshot_to_tests.rb
+++ b/db/migrate/20161101215031_add_attachment_snapshot_to_tests.rb
@@ -1,0 +1,11 @@
+class AddAttachmentSnapshotToTests < ActiveRecord::Migration
+  def self.up
+    change_table :tests do |t|
+      t.attachment :snapshot
+    end
+  end
+
+  def self.down
+    remove_attachment :tests, :snapshot
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161030164753) do
+ActiveRecord::Schema.define(version: 20161101215031) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,11 +51,15 @@ ActiveRecord::Schema.define(version: 20161030164753) do
   create_table "tests", force: :cascade do |t|
     t.string   "name"
     t.string   "test_url"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
     t.integer  "test_type_id"
     t.string   "slug"
     t.integer  "user_id"
+    t.string   "snapshot_file_name"
+    t.string   "snapshot_content_type"
+    t.integer  "snapshot_file_size"
+    t.datetime "snapshot_updated_at"
     t.index ["slug"], name: "index_tests_on_slug", unique: true, using: :btree
     t.index ["test_type_id"], name: "index_tests_on_test_type_id", using: :btree
     t.index ["user_id"], name: "index_tests_on_user_id", using: :btree


### PR DESCRIPTION
closes #179 

Changes:
- uses IMGKit gem to handle screenshot
- uses paperclip gem to attach image to Test model
- uses aws - sdk gem to upload to s3

To run:
- bundle
- db:migrate (for snapshot columns in Test db)
- .env file created but added to gitignore:

Tests:
- when test suite is run, snapshots are dropped into public folder atm (s3 only set in dev and prod environments)
- not sure how to deal with this atm - have just deleted the images from public manually after running rspec!

To think about:
- won't work for github URLs

Heroku:
- not deployed to Heroku yet
- will need some config re:
      1. ENV variables
      2. IMGKit setup for Heroku - https://github.com/csquared/IMGKit